### PR TITLE
Bump versions of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.6.6'
+	id 'org.springframework.boot' version '2.7.18'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'jacoco'
@@ -48,25 +48,25 @@ dependencies {
 //	}
 //	implementation "org.springframework.boot:spring-boot-starter-undertow"
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.security:spring-security-acl'
 
-	implementation (group: 'org.liquibase', name: 'liquibase-core', version: "4.6.1")
+	implementation (group: 'org.liquibase', name: 'liquibase-core', version: "4.9.1")
 	compileOnly 'org.projectlombok:lombok:1.18.20'
 	annotationProcessor 'org.projectlombok:lombok:1.18.20'
 	implementation "com.zaxxer:HikariCP:4.0.3"
-	implementation "org.postgresql:postgresql:42.2.23"
+	implementation "org.postgresql:postgresql:42.2.28"
 	implementation 'com.vladmihalcea:hibernate-types-55:2.14.0'
 	implementation "org.hibernate.validator:hibernate-validator:6.1.6.Final"
-	implementation "com.fasterxml.jackson.datatype:jackson-datatype-hppc:2.10.4"
-	implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.4"
-	implementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.10.4"
-	implementation "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.10.4"
-	implementation "com.fasterxml.jackson.core:jackson-annotations:2.10.4"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.10.4"
+	implementation "com.fasterxml.jackson.datatype:jackson-datatype-hppc:2.14.3"
+	implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+	implementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.14.3"
+	implementation "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.14.3"
+	implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.3"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.14.3"
 	implementation 'org.hibernate:hibernate-spatial:5.3.10.Final'
 	implementation "commons-codec:commons-codec:1.6"
 
@@ -75,7 +75,7 @@ dependencies {
 	annotationProcessor('org.hibernate:hibernate-jpamodelgen')
 
 	testImplementation 'org.assertj:assertj-core:3.4.1'
-	implementation 'org.apache.commons:commons-text:1.9'
+	implementation 'org.apache.commons:commons-text:1.12.0'
 	testImplementation 'com.github.tomakehurst:wiremock:1.58'
 	implementation 'com.vividsolutions:jts:1.13'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'


### PR DESCRIPTION
This PR bumps some versions to solve some outdated dependencies that show some security vulnerabilities based on [grype](https://github.com/anchore/grype).

Probably a more extensive updated is required, such as updating springframework to version >=3, and updating java version such that the openjdk container can be updated to a newer version with security updates, but this will likely require application changes.

I have run the tests locally, and they seem to give the same results on main and this PR (5 of 2329 tests fail) & have tested the container locally with a running application. Let me know if anything else is needed to test, or if you see any issues.